### PR TITLE
updating to chef version: 15.17.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV CHEF_VERSION 14.15.6
+ENV CHEF_VERSION 15.17.4
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:bullseye
 
 ENV CHEF_VERSION 15.17.4
 ENV DEBIAN_FRONTEND noninteractive
+ENV CHEF_LICENSE accept-silent
 
 RUN apt-get update && apt-get install -y \
       curl \


### PR DESCRIPTION
fixes:
```
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/cloudflair/libraries/_autoload.rb
================================================================================
Mixlib::ShellOut::ShellCommandFailed
------------------------------------
chef_gem[cloudflair] (dynamically defined) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process>
---- Begin output of /opt/chef/embedded/bin/gem install cloudflair -q --no-rdoc --no-ri -v "= 0.3.0" --source=h>
STDOUT: Successfully installed concurrent-ruby-1.1.9
STDERR: ERROR:  Error installing cloudflair:
       The last version of dry-core (>= 0.5.0, ~> 0.5) to support your Ruby & RubyGems was 0.6.0. Try installi>
       dry-core requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
---- End output of /opt/chef/embedded/bin/gem install cloudflair -q --no-rdoc --no-ri -v "= 0.3.0" --source=htt>
Ran /opt/chef/embedded/bin/gem install cloudflair -q --no-rdoc --no-ri -v "= 0.3.0" --source=https://www.rubyge>
Cookbook Trace:
---------------
 /var/chef/cache/cookbooks/cloudflair/libraries/_autoload.rb:11:in `rescue in <top (required)>'
 /var/chef/cache/cookbooks/cloudflair/libraries/_autoload.rb:1:in `<top (required)>'
Relevant File Content:
----------------------
/var/chef/cache/cookbooks/cloudflair/libraries/_autoload.rb:

 4:    unless defined?(ChefSpec)
 5:      run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
 6:
 7:      require 'chef/resource/chef_gem'
 8:
 9:      cloudflair = Chef::Resource::ChefGem.new('cloudflair', run_context)
10:      cloudflair.version '= 0.3.0'
11>>     cloudflair.run_action(:install)
12:    end
13:  end
14:  
System Info:
------------
chef_version=14.15.6
platform=debian
platform_version=bullseye/sid
ruby=ruby 2.5.8p224 (2020-03-31 revision 67882) [x86_64-linux]
program_name=/usr/bin/chef-client
executable=/opt/chef/bin/chef-client

Running handlers:
[2021-07-13T19:06:57+00:00] ERROR: Running exception handlers
Running handlers complete
[2021-07-13T19:06:57+00:00] ERROR: Exception handlers complete
Chef Client failed. 0 resources updated in 09 seconds
[2021-07-13T19:06:57+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2021-07-13T19:06:57+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug rep>
[2021-07-13T19:06:57+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: chef_gem[cloudflair] (dynamically defi>
---- Begin output of /opt/chef/embedded/bin/gem install cloudflair -q --no-rdoc --no-ri -v "= 0.3.0" --source=h>
STDOUT: Successfully installed concurrent-ruby-1.1.9
STDERR: ERROR:  Error installing cloudflair:
       The last version of dry-core (>= 0.5.0, ~> 0.5) to support your Ruby & RubyGems was 0.6.0. Try installi>
       dry-core requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
---- End output of /opt/chef/embedded/bin/gem install cloudflair -q --no-rdoc --no-ri -v "= 0.3.0" --source=htt>
Ran /opt/chef/embedded/bin/gem install cloudflair -q --no-rdoc --no-ri -v "= 0.3.0" --source=https://www.rubyge>
```