### PR TITLE
updating to chef version: 16.13.16

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,0 +1,61 @@
+name: docker
+
+on:
+  # schedule:
+  #   - cron: '0 10 * * *' # everyday at 10am
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  autobuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            anthonyneto/chef-client
+            ghcr.io/anthonyneto/chef-client
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:bullseye
 
-ENV CHEF_VERSION 15.17.4
-ENV DEBIAN_FRONTEND noninteractive
+ENV CHEF_VERSION 16.13.16
 ENV CHEF_LICENSE accept-silent
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y \
       curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
       kmod \
       systemd \
       iproute2 \
+      dmidecode \
     && curl -sLo /chef.deb "https://packages.chef.io/files/stable/chef/${CHEF_VERSION}/debian/10/chef_${CHEF_VERSION}-1_amd64.deb" \
     && dpkg -i /chef.deb \
     && rm -f /chef.deb \


### PR DESCRIPTION
Gotta fix the below issue first:
```
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/neto_server/recipes/default.rb
================================================================================

NoMethodError
-------------
undefined method `docker_image' for cookbook: neto_server, recipe: docker-gc :Chef::Recipe

Cookbook Trace: (most recent call first)
----------------------------------------
  /var/chef/cache/cookbooks/neto_server/recipes/docker-gc.rb:1:in `from_file'
  /var/chef/cache/cookbooks/neto_server/recipes/default.rb:2:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/neto_server/recipes/docker-gc.rb:

  1>> docker_image 'docker' do
  2:    tag 'dind'
  3:  end
  4:  
  5:  docker_container 'docker-system-prune' do
  6:    repo 'docker'
  7:    tag 'dind'
  8:    autoremove true
  9:    command 'docker system prune -fa --volumes'
 10:    volumes ['/var/run/docker.sock:/var/run/docker.sock']

System Info:
------------
chef_version=16.13.16
platform=debian
platform_version=11
ruby=ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-linux]
program_name=/usr/bin/chef-client
executable=/opt/chef/bin/chef-client
```